### PR TITLE
Update choice text and gui representation

### DIFF
--- a/src/main/java/seedu/address/model/choice/Choice.java
+++ b/src/main/java/seedu/address/model/choice/Choice.java
@@ -46,7 +46,7 @@ public class Choice {
 
     @Override
     public String toString() {
-        return title;
+        return title + (isCorrect ? " (answer)" : "");
     }
 
     @Override

--- a/src/main/java/seedu/address/model/question/Question.java
+++ b/src/main/java/seedu/address/model/question/Question.java
@@ -101,22 +101,40 @@ public abstract class Question {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
+
+        appendImportance(builder);
+        appendTags(builder);
+        appendChoices(builder);
+
+        return builder.toString();
+    }
+
+    private StringBuilder appendImportance(StringBuilder builder) {
         builder.append(getName())
                 .append("; Importance: ")
                 .append(getImportance());
+        return builder;
+    }
 
+    private StringBuilder appendTags(StringBuilder builder) {
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");
             tags.forEach(builder::append);
         }
+        return builder;
+    }
 
+    private StringBuilder appendChoices(StringBuilder builder) {
         Set<Choice> choices = getChoices();
         if (!choices.isEmpty()) { // may be empty for open-ended questions
             builder.append("; Choices: ");
-            choices.forEach(builder::append);
+            for (Choice choice: choices) {
+                builder.append(choice).append(", ");
+            }
+            builder.setLength(builder.length() - 2); //remove ", " after last choice
         }
-        return builder.toString();
+        return builder;
     }
 
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -350,3 +350,19 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#choices {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#choices .label {
+    -fx-text-fill: white;
+    -fx-background-color: #035546;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 14;
+}
+
+

--- a/src/test/java/seedu/address/model/choice/ChoiceTest.java
+++ b/src/test/java/seedu/address/model/choice/ChoiceTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.choice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -50,5 +51,14 @@ public class ChoiceTest {
         assertFalse(choiceBCorrect.equals(choiceACorrect));
 
         assertTrue(choiceACorrect.equals(new Choice("choice A", true)));
+    }
+
+    @Test
+    public void toString_test() {
+        Choice wrongChoice = new Choice("wrong", false);
+        Choice correctChoice = new Choice("correct", true);
+
+        assertEquals(wrongChoice.toString(), "wrong");
+        assertEquals(correctChoice.toString(), "correct (answer)");
     }
 }


### PR DESCRIPTION
Previously when an mcq is added like "mcq qn/what is 2+2? opt/1 opt/2 opt/3 ans/4 i/2", the choices in the success message shown to the user are not separated by commas: "New question added: a??; Importance: 2; Choices: 1234". This PR fixes this bug so the choices will be shown as Choices: 1, 2, 3, 4 (answer).

GUI update: updated the GUI so that Choices show up and look similar to tags. This is a very rough draft, mainly to make testing v1.2 more convenient. Styling/formatting should be changed in future.


resolves [#31](https://github.com/AY2122S1-CS2103T-F12-1/tp/issues/31)