### PR TITLE
Change gui so question text is not truncated

### DIFF
--- a/src/main/java/seedu/smartnus/ui/QuestionCard.java
+++ b/src/main/java/seedu/smartnus/ui/QuestionCard.java
@@ -26,13 +26,12 @@ public class QuestionCard extends UiPart<Region> {
      */
 
     public final Question question;
+    private int displayedIndex;
 
     @FXML
     private HBox cardPane;
     @FXML
     private Label name;
-    @FXML
-    private Label id;
     @FXML
     private Label importance;
     @FXML
@@ -40,7 +39,7 @@ public class QuestionCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
     @FXML
-    private FlowPane choices;
+    private HBox choices;
 
     /**
      * Creates a {@code QuestionCard} with the given {@code Question} and index to display.
@@ -48,9 +47,10 @@ public class QuestionCard extends UiPart<Region> {
     public QuestionCard(Question question, int displayedIndex) {
         super(FXML);
         this.question = question;
-        id.setText(displayedIndex + ". ");
-        name.setText(question.getName().fullName);
-        importance.setText("importance: " + question.getImportance().value);
+        this.displayedIndex = displayedIndex;
+        name.setText(displayedIndex + ". " + question.getName().fullName);
+        name.setWrapText(true);
+        importance.setText("Importance: " + question.getImportance().value);
         question.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
@@ -63,6 +63,7 @@ public class QuestionCard extends UiPart<Region> {
     // If not, during quiz, users can see the correct answers
     private void setChoiceLabel(Choice choice) {
         Label choiceLabel = new Label(choice.getTitle());
+        choiceLabel.setWrapText(true);
         if (choice.getIsCorrect()) {
             choiceLabel.getStyleClass().add("correct-choice-bg");
         } else {
@@ -85,7 +86,7 @@ public class QuestionCard extends UiPart<Region> {
 
         // state check
         QuestionCard card = (QuestionCard) other;
-        return id.getText().equals(card.id.getText())
+        return displayedIndex == card.displayedIndex
                 && question.equals(card.question);
     }
 }

--- a/src/main/resources/view/QuestionListCard.fxml
+++ b/src/main/resources/view/QuestionListCard.fxml
@@ -19,18 +19,12 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
-          <minWidth>
-            <!-- Ensures that the label text is never truncated -->
-            <Region fx:constant="USE_PREF_SIZE" />
-          </minWidth>
-        </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="importance" styleClass="cell_small_label" text="\$importance" />
       <Label fx:id="statistic" styleClass="cell_small_label" text="\$statistic" />
-      <FlowPane fx:id="choices" />
+      <HBox  spacing="5" fx:id="choices" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
Previously, text was truncated for both question titles and choices if they were longer than the window width. This PR sets text-wrapping for Question and Choice Labels. FlowPane for choices was changed to a HBox as FlowPane seemed to prevent text-wrapping of labels. The Label for id/displayedIndex was removed as if it was left, the id would appear in the middle row of the quesiton (eg. if the question spanned three rows, the question number would appear on the left of the second row). Instead, I appended the index to the question title.

Before (truncated):
![image](https://user-images.githubusercontent.com/36692484/138594824-4ac75f4e-6797-4b8e-bab4-c66742f97e2a.png)

After:
![image](https://user-images.githubusercontent.com/36692484/138594864-4d370ccc-78c4-4f1e-8b33-d88f390c55e7.png)

