### PR TITLE
fix saq adding duplicate correct attempts stats

### DIFF
--- a/src/main/java/seedu/smartnus/model/question/ShortAnswerQuestion.java
+++ b/src/main/java/seedu/smartnus/model/question/ShortAnswerQuestion.java
@@ -55,25 +55,9 @@ public class ShortAnswerQuestion extends Question {
 
     @Override
     public boolean isCorrectAnswer(Choice choiceToCheck) {
-        Set<Choice> saqAnswers = getChoices();
-        for (Choice answer : saqAnswers) {
-            if (hasAllKeywords(choiceToCheck, answer)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean hasAllKeywords(Choice choiceToCheck, Choice answer) {
+        Choice answer = getCorrectChoice();
         String input = choiceToCheck.getTitle(); // user input is passed as a selected choice
-        if (containsAllKeywords(input, answer.getKeywords())) {
-            getStatistic().addCorrect();
-            return true;
-        }
-        return false;
-    }
-
-    private boolean containsAllKeywords(String input, Set<String> keywords) {
+        Set<String> keywords = answer.getKeywords();
         for (String keyword : keywords) {
             if (!input.toLowerCase().contains(keyword.toLowerCase())) {
                 return false;

--- a/src/test/java/seedu/smartnus/model/question/ShortAnswerQuestionTest.java
+++ b/src/test/java/seedu/smartnus/model/question/ShortAnswerQuestionTest.java
@@ -23,7 +23,7 @@ public class ShortAnswerQuestionTest {
     @BeforeEach
     void setUp() {
         Set<Choice> validSaqChoices = new HashSet<>();
-        validSaqChoices.add(new Choice(VALID_SAQ_ANSWER_1, false, new HashSet<>(List.of("j", "Rowling"))));
+        validSaqChoices.add(new Choice(VALID_SAQ_ANSWER_1, true, new HashSet<>(List.of("j", "Rowling"))));
         validSaq = new ShortAnswerQuestion(new Name(VALID_QUESTION_1),
                 new Importance(VALID_IMPORTANCE_1), new HashSet<>(), validSaqChoices);
     }
@@ -37,11 +37,11 @@ public class ShortAnswerQuestionTest {
     }
 
     @Test
-    public void attemptAndCheckAnswer_incorrectAnswer_false() {
-        Choice correctAns1 = new Choice("J K Rowl", true);
-        Choice correctAns2 = new Choice("J K", true);
-        assertFalse(validSaq.attemptAndCheckAnswer(correctAns1));
-        assertFalse(validSaq.attemptAndCheckAnswer(correctAns2));
+    public void attemptAndCheckAnswer_wrongAnswer_false() {
+        Choice wrongAns1 = new Choice("J K Rowl", true);
+        Choice wrongAns2 = new Choice("J K", true);
+        assertFalse(validSaq.attemptAndCheckAnswer(wrongAns1));
+        assertFalse(validSaq.attemptAndCheckAnswer(wrongAns2));
     }
 
     @Test


### PR DESCRIPTION
Adding duplicate correct attempts was caused by an additional call to getStatistic().addCorrect(); in hasAllKeywords method. I have also refactored some saq methods to be more succinct.

Closes #156 