### PR TITLE
decrease time lag for list/add question

### DIFF
--- a/src/main/java/seedu/smartnus/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/smartnus/logic/commands/ListCommand.java
@@ -5,7 +5,6 @@ import static seedu.smartnus.logic.commands.CommandUtil.NOTE_KEYWORD;
 import static seedu.smartnus.logic.commands.CommandUtil.QUESTION_KEYWORD;
 import static seedu.smartnus.logic.commands.CommandUtil.TAG_KEYWORD;
 import static seedu.smartnus.model.Model.PREDICATE_SHOW_ALL_NOTES;
-import static seedu.smartnus.model.Model.PREDICATE_SHOW_ALL_QUESTIONS;
 import static seedu.smartnus.model.Model.PREDICATE_SHOW_ALL_STATISTICS;
 
 import seedu.smartnus.model.Model;
@@ -45,7 +44,7 @@ public class ListCommand extends Command {
         String successMessage;
         switch (panel) {
         case QUESTION_KEYWORD:
-            model.updateFilteredQuestionList(PREDICATE_SHOW_ALL_QUESTIONS);
+            model.resetFilteredQuestionList();
             model.setPanel(QUESTION_KEYWORD);
             successMessage = MESSAGE_SUCCESS_QUESTIONS;
 
@@ -64,7 +63,7 @@ public class ListCommand extends Command {
             break;
         default:
             // Defensive programming
-            model.updateFilteredQuestionList(PREDICATE_SHOW_ALL_QUESTIONS);
+            model.resetFilteredQuestionList();
             model.setPanel(QUESTION_KEYWORD);
             successMessage = MESSAGE_SUCCESS_QUESTIONS;
         }

--- a/src/main/java/seedu/smartnus/model/Model.java
+++ b/src/main/java/seedu/smartnus/model/Model.java
@@ -96,7 +96,11 @@ public interface Model {
     void updateFilteredQuestionList(Predicate<Question> predicate);
 
     /**
+     * Resets the filtered question list to contain all questions.
+     */
+    void resetFilteredQuestionList();
 
+    /**
      * Adds the given note.
      */
     void addNote(Note note);

--- a/src/main/java/seedu/smartnus/model/ModelManager.java
+++ b/src/main/java/seedu/smartnus/model/ModelManager.java
@@ -27,7 +27,7 @@ public class ModelManager implements Model {
 
     private final SmartNus smartNus;
     private final UserPrefs userPrefs;
-    private final FilteredList<Question> filteredQuestions;
+    private FilteredList<Question> filteredQuestions;
     private final FilteredList<Note> filteredNotes;
     private FilteredList<Question> filteredQuizQuestions;
     private FilteredList<TagStatistic> filteredTagStatistic;
@@ -130,7 +130,7 @@ public class ModelManager implements Model {
     @Override
     public void addQuestion(Question question) {
         smartNus.addQuestion(question);
-        updateFilteredQuestionList(PREDICATE_SHOW_ALL_QUESTIONS);
+        resetFilteredQuestionList();
     }
 
     @Override
@@ -185,6 +185,11 @@ public class ModelManager implements Model {
     public void updateFilteredQuestionList(Predicate<Question> predicate) {
         requireNonNull(predicate);
         filteredQuestions.setPredicate(predicate);
+    }
+
+    @Override
+    public void resetFilteredQuestionList() {
+        filteredQuestions = new FilteredList<>(this.smartNus.getQuestionList());
     }
 
     //=========== Filtered Note List Accessors =============================================================

--- a/src/test/java/seedu/smartnus/logic/commands/AddMcqCommandTest.java
+++ b/src/test/java/seedu/smartnus/logic/commands/AddMcqCommandTest.java
@@ -179,6 +179,11 @@ class AddMcqCommandTest {
         }
 
         @Override
+        public void resetFilteredQuestionList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void sortFilteredQuizQuestionList(Comparator<Question> comparator) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/smartnus/logic/commands/AddNoteCommandTest.java
+++ b/src/test/java/seedu/smartnus/logic/commands/AddNoteCommandTest.java
@@ -120,6 +120,11 @@ public class AddNoteCommandTest {
         }
 
         @Override
+        public void resetFilteredQuestionList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addNote(Note note) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/smartnus/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/smartnus/logic/commands/EditCommandTest.java
@@ -133,7 +133,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new SmartNus(model.getSmartNus()), new UserPrefs());
         expectedModel.setQuestion(model.getFilteredQuestionList().get(0), editedQuestion);
-        model.updateFilteredQuestionList(Model.PREDICATE_SHOW_ALL_QUESTIONS);
+        model.resetFilteredQuestionList();
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/smartnus/model/ModelManagerTest.java
+++ b/src/test/java/seedu/smartnus/model/ModelManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.smartnus.model.Model.PREDICATE_SHOW_ALL_QUESTIONS;
 import static seedu.smartnus.testutil.Assert.assertThrows;
 import static seedu.smartnus.testutil.TypicalQuestions.ALICE;
 import static seedu.smartnus.testutil.TypicalQuestions.BENSON;
@@ -131,7 +130,7 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(smartNus, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
-        modelManager.updateFilteredQuestionList(PREDICATE_SHOW_ALL_QUESTIONS);
+        modelManager.resetFilteredQuestionList();
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();


### PR DESCRIPTION
time lag is somehow due to updating filtered list with the SHOW_ALL_QUESTIONS predicate. Actually, there is a lag when adding questions as well due to the same method being used. It is quite weird though that this happens when there are only ~10 questions. If anyone has a better way to resolve this/can make listing questions more efficient please help to refactor the code as well.

Test on this branch and on master the ```list question``` and ```mcq qn/test opt/1 opt/2 opt/3 ans/4 i/2``` to see the difference in time.

Addresses #175