### PR TITLE
Update FindCommand and documentation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -243,7 +243,7 @@ To return to the list of all questions, use the `list question` command.
 </div>
 
 Examples:
-* `find load word t/CS2100 t/MIPS i/2` returns questions tagged with at least one of the tags and whose title
+* `find load word t/CS2100 t/MIPS i/2` returns questions tagged with at least one of the tags, with importance value 2 and whose title
 includes "load" and "word" in any order.
   * e.g. A question titled "What is the load word instruction used for?" tagged with only CS2100 and with an importance value of 2 will be listed.
 * `find java` returns a question titled "How do you output text to the console in Java?" but not a question titled "Javascript is commonly used in web development. True or false?" (since `java` is not a full word match for `javascript`).

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -223,11 +223,13 @@ Format: `find [KEYWORDS]... [t/TAG]... [i/IMPORTANCE]`
 * At least one of the optional fields to find by must be specified.
 * The search is case-insensitive for both keywords and tags (e.g. `math` will match `MaTH`).
 * Only full words will be matched for both keywords and tags (e.g. `CS2100` will not match `CS210`).
-* A word is a string of characters with a space at either the beginning or the end.
-* The following punctuation marks `,.?!:;*"()[]{}` commonly found at the beginning or end of a word are not considered part of the word
-  (i.e. `find *("literature":,;?!)]}` is the same as `find literature` and `find a b` will return a question with `(a:b)` in its title).
+* The following characters `,.?!:;*"()[]{}` which are commonly used to separate words are not considered part of a word or keyword. 
+Instead, they are considered as word separators similar to a space.
+  * `find *("literature":,;?!)]}` returns the same result as `find literature`.
+  * `find ,:;?(]` is an invalid command as it is the same as finding a blank keyword or only inputting spaces as keywords.
+  * `find first? second (third...)!` is the same as `find first second third`.
 * Hyphenated words are considered as one word (e.g. `find grey-box` will not return a question titled `grey box`).
-* Any question that has at least one of the tags **AND** and all the keywords in its title (in any order)
+* Any question that has at least one of the tags **AND** all the keywords in its title (in any order)
 **AND** the importance specified will be listed.
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
@@ -241,9 +243,10 @@ To return to the list of all questions, use the `list question` command.
 </div>
 
 Examples:
-* `find load word t/CS2100 t/MIPS` returns questions tagged with at least one of the tags and that whose title
+* `find load word t/CS2100 t/MIPS i/2` returns questions tagged with at least one of the tags and whose title
 includes "load" and "word" in any order.
-  * e.g. A question titled "What is the load word instruction used for?" tagged with only CS2100 will be listed.
+  * e.g. A question titled "What is the load word instruction used for?" tagged with only CS2100 and with an importance value of 2 will be listed.
+* `find java` returns a question titled "How do you output text to the console in Java?" but not a question titled "Javascript is commonly used in web development. True or false?" (since `java` is not a full word match for `javascript`).
 
 <!-- TODO: standardise format, remove params from header, add brief description-->
 #### 4.1.9. Find/Search Stats: `stat [t/TAG]...`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -223,6 +223,10 @@ Format: `find [KEYWORDS]... [t/TAG]... [i/IMPORTANCE]`
 * At least one of the optional fields to find by must be specified.
 * The search is case-insensitive for both keywords and tags (e.g. `math` will match `MaTH`).
 * Only full words will be matched for both keywords and tags (e.g. `CS2100` will not match `CS210`).
+* A word is a string of characters with a space at either the beginning or the end.
+* The following punctuation marks `,.?!:;*"()[]{}` commonly found at the beginning or end of a word are not considered part of the word
+  (i.e. `find *("literature":,;?!)]}` is the same as `find literature` and `find a b` will return a question with `(a:b)` in its title).
+* Hyphenated words are considered as one word (e.g. `find grey-box` will not return a question titled `grey box`).
 * Any question that has at least one of the tags **AND** and all the keywords in its title (in any order)
 **AND** the importance specified will be listed.
 

--- a/src/main/java/seedu/smartnus/commons/util/StringUtil.java
+++ b/src/main/java/seedu/smartnus/commons/util/StringUtil.java
@@ -32,7 +32,7 @@ public class StringUtil {
         checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
 
         String preppedSentence = sentence;
-        String[] wordsInPreppedSentence = preppedSentence.split("([,.?!:;*\"-()\\[\\]{}]|\\s)+");
+        String[] wordsInPreppedSentence = preppedSentence.split("([,.?!:;*\"()\\[\\]{}]|\\s)+");
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);

--- a/src/main/java/seedu/smartnus/commons/util/StringUtil.java
+++ b/src/main/java/seedu/smartnus/commons/util/StringUtil.java
@@ -32,7 +32,7 @@ public class StringUtil {
         checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
 
         String preppedSentence = sentence;
-        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+        String[] wordsInPreppedSentence = preppedSentence.split("([,.?!:;*\"-()\\[\\]{}]|\\s)+");
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);

--- a/src/main/java/seedu/smartnus/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/smartnus/logic/commands/FindCommand.java
@@ -36,7 +36,7 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_NO_FIELDS_SPECIFIED = "You must specify at least one keyword or parameter"
             + " to filter questions by.";
-    
+
     public static final String MESSAGE_INVALID_KEYWORDS =
             "Valid keywords must include characters that are considered part of a word."
             + " The following characters commonly used to separate words"

--- a/src/main/java/seedu/smartnus/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/smartnus/logic/commands/FindCommand.java
@@ -36,6 +36,11 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_NO_FIELDS_SPECIFIED = "You must specify at least one keyword or parameter"
             + " to filter questions by.";
+    
+    public static final String MESSAGE_INVALID_KEYWORDS =
+            "Valid keywords must include characters that are considered part of a word."
+            + " The following characters commonly used to separate words"
+            + " are NOT considered part of a word: ,.?!:;*()[]{}\"";
 
     private final Set<Predicate<Question>> predicateSet = new HashSet<>();
     private final Predicate<Question> combinedPredicate;

--- a/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
@@ -75,11 +75,14 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
     }
 
-    private void setNamePredicate(ArgumentMultimap argMultimap, ArrayList<Predicate<Question>> predicates) {
+    private void setNamePredicate(ArgumentMultimap argMultimap, ArrayList<Predicate<Question>> predicates) throws ParseException {
         String nameInput = argMultimap.getPreamble();
         if (!nameInput.isBlank()) {
             List<String> parsedNameKeywords = Stream.of(nameInput.trim().split("([,.?!:;*\"-()\\[\\]{}]|\\s)+"))
                     .filter(keyword -> !keyword.isEmpty()).collect(Collectors.toList());
+            if (parsedNameKeywords.isEmpty()) {
+                throw new ParseException("Please input valid keywords (characters that are considered part of a word). The following characters are not considered part of a word: ,.?!:;*-()[]{}]\"");
+            }
             predicates.add(new NameContainsKeywordsPredicate(parsedNameKeywords));
         }
     }

--- a/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.smartnus.logic.parser;
 
 import static seedu.smartnus.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.smartnus.logic.commands.FindCommand.MESSAGE_INVALID_KEYWORDS;
 import static seedu.smartnus.logic.parser.CliSyntax.PREFIX_IMPORTANCE;
 import static seedu.smartnus.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -78,10 +79,10 @@ public class FindCommandParser implements Parser<FindCommand> {
     private void setNamePredicate(ArgumentMultimap argMultimap, ArrayList<Predicate<Question>> predicates) throws ParseException {
         String nameInput = argMultimap.getPreamble();
         if (!nameInput.isBlank()) {
-            List<String> parsedNameKeywords = Stream.of(nameInput.trim().split("([,.?!:;*\"-()\\[\\]{}]|\\s)+"))
+            List<String> parsedNameKeywords = Stream.of(nameInput.trim().split("([,.?!:;*\"()\\[\\]{}]|\\s)+"))
                     .filter(keyword -> !keyword.isEmpty()).collect(Collectors.toList());
             if (parsedNameKeywords.isEmpty()) {
-                throw new ParseException("Please input valid keywords (characters that are considered part of a word). The following characters are not considered part of a word: ,.?!:;*-()[]{}]\"");
+                throw new ParseException(MESSAGE_INVALID_KEYWORDS);
             }
             predicates.add(new NameContainsKeywordsPredicate(parsedNameKeywords));
         }

--- a/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
@@ -78,7 +78,7 @@ public class FindCommandParser implements Parser<FindCommand> {
     private void setNamePredicate(ArgumentMultimap argMultimap, ArrayList<Predicate<Question>> predicates) {
         String nameInput = argMultimap.getPreamble();
         if (!nameInput.isBlank()) {
-            List<String> parsedNameKeywords = Stream.of(nameInput.trim().split("\\s+"))
+            List<String> parsedNameKeywords = Stream.of(nameInput.trim().split("([,.?!:;*\"-()\\[\\]{}]|\\s)+"))
                     .filter(keyword -> !keyword.isEmpty()).collect(Collectors.toList());
             predicates.add(new NameContainsKeywordsPredicate(parsedNameKeywords));
         }

--- a/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/smartnus/logic/parser/FindCommandParser.java
@@ -76,7 +76,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
     }
 
-    private void setNamePredicate(ArgumentMultimap argMultimap, ArrayList<Predicate<Question>> predicates) throws ParseException {
+    private void setNamePredicate(ArgumentMultimap argMultimap, ArrayList<Predicate<Question>> predicates)
+            throws ParseException {
         String nameInput = argMultimap.getPreamble();
         if (!nameInput.isBlank()) {
             List<String> parsedNameKeywords = Stream.of(nameInput.trim().split("([,.?!:;*\"()\\[\\]{}]|\\s)+"))

--- a/src/main/java/seedu/smartnus/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/smartnus/model/util/SampleDataUtil.java
@@ -22,7 +22,7 @@ import seedu.smartnus.model.tag.Tag;
  * Contains utility methods for populating {@code SmartNus} with sample data.
  */
 public class SampleDataUtil {
-    public static final int SAQ_QUESTION_INDEX = 3;
+    public static final int SAQ_QUESTION_INDEX = 2;
     public static Question[] getSampleQuestions() {
         return new Question[] {
             new MultipleChoiceQuestion(

--- a/src/main/java/seedu/smartnus/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/smartnus/model/util/SampleDataUtil.java
@@ -26,35 +26,22 @@ public class SampleDataUtil {
     public static Question[] getSampleQuestions() {
         return new Question[] {
             new MultipleChoiceQuestion(
-                    new Name("The mean and variance of a random variable X are 5 and 8. What is E(X)?"),
-                    new Importance("2"), getTagSet("ST2334"),
-                    getChoiceSet(new Choice("5", true), new Choice("4", false),
-                            new Choice("7", false), new Choice("8", false))
-            ),
-            new MultipleChoiceQuestion(
-                    new Name("What is the maximum line length according to CS2103T's coding standard?"),
+                    new Name("What is the maximum line length according to the CS2103T coding standard?"),
                     new Importance("2"), getTagSet("CS2103T", "Java", "style"),
                     getChoiceSet(new Choice("120", true), new Choice("110", false),
                             new Choice("100", false), new Choice("130", false))
             ),
             new TrueFalseQuestion(
                     new Name("Grey-box test case design is a mixture of specification-based"
-                            + " and implementation-based approaches.?"),
+                            + " and implementation-based approaches?"),
                     new Importance("2"), getTagSet("CS2103T", "Java", "Testing"),
                     getChoiceSet(new Choice("True", true), new Choice("False", false))
             ),
             new ShortAnswerQuestion(
                     new Name("What is J.K. Rowling's first book about a boy wizard called?"),
-                    new Importance("2"), getTagSet("books", "trivia"),
+                    new Importance("2"), getTagSet("Books", "Literature"),
                         getChoiceSet(new Choice("Harry Potter and the Philosopher's Stone", true,
                                 new HashSet<>(List.of("Harry", "Potter"))))
-            ),
-            new MultipleChoiceQuestion(
-                    new Name("The mean of a random variable X is 10 and E(X^2) = 20. "
-                            + "What is the standard deviation of X?"),
-                    new Importance("2"), getTagSet("ST2334"),
-                    getChoiceSet(new Choice("8.94", true), new Choice("80.0", false),
-                            new Choice("60.0", false), new Choice("7.78", false))
             ),
             new MultipleChoiceQuestion(new Name("Which of the following logic gates is a universal gate?"),
                     new Importance("1"), getTagSet("CS2100"),
@@ -67,11 +54,11 @@ public class SampleDataUtil {
                     new Importance("2"), getTagSet("CS2103T", "Java", "Design"),
                     getChoiceSet(new Choice("True", false), new Choice("False", true))
             ),
-            new MultipleChoiceQuestion(new Name("Convert the following MIPS instruction into hexadecimal: "
-                    + "lw $t9, 0($t7)"),
-                    new Importance("3"), getTagSet("CS2100", "MIPS"),
-                    getChoiceSet(new Choice("0x8df90000", true), new Choice("0x8ed90000", false),
-                            new Choice("0x8df80000", false), new Choice("0x8de90000", false))
+            new ShortAnswerQuestion(
+                    new Name("What organelle is commonly known as the powerhouse of the cell?"),
+                    new Importance("2"), getTagSet("Biology"),
+                    getChoiceSet(new Choice("Mitochondria", true,
+                                new HashSet<>(List.of("Mitochondria"))))
             ),
             new MultipleChoiceQuestion(
                     new Name("What are class diagrams that are used to model the problem domain called?"),

--- a/src/main/java/seedu/smartnus/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/smartnus/model/util/SampleDataUtil.java
@@ -22,6 +22,8 @@ import seedu.smartnus.model.tag.Tag;
  * Contains utility methods for populating {@code SmartNus} with sample data.
  */
 public class SampleDataUtil {
+    public static final int MCQ_QUESTION_INDEX = 0;
+    public static final int TFQ_QUESTION_INDEX = 1;
     public static final int SAQ_QUESTION_INDEX = 2;
     public static Question[] getSampleQuestions() {
         return new Question[] {

--- a/src/test/java/seedu/smartnus/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/smartnus/logic/commands/FindCommandTest.java
@@ -6,12 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.smartnus.commons.core.Messages.MESSAGE_QUESTIONS_LISTED_OVERVIEW;
 import static seedu.smartnus.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.smartnus.logic.commands.CommandUtil.QUESTION_KEYWORD;
-import static seedu.smartnus.testutil.TypicalQuestions.FIONA;
-import static seedu.smartnus.testutil.TypicalSmartNus.getTypicalSmartNus;
+import static seedu.smartnus.model.util.SampleDataUtil.MCQ_QUESTION_INDEX;
+import static seedu.smartnus.model.util.SampleDataUtil.TFQ_QUESTION_INDEX;
+import static seedu.smartnus.model.util.SampleDataUtil.getSampleQuestions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -19,29 +21,39 @@ import org.junit.jupiter.api.Test;
 import seedu.smartnus.model.Model;
 import seedu.smartnus.model.ModelManager;
 import seedu.smartnus.model.UserPrefs;
+import seedu.smartnus.model.question.Importance;
 import seedu.smartnus.model.question.Question;
+import seedu.smartnus.model.question.predicates.HasImportancePredicate;
 import seedu.smartnus.model.question.predicates.NameContainsKeywordsPredicate;
+import seedu.smartnus.model.question.predicates.TagsContainKeywordsPredicate;
+import seedu.smartnus.model.util.SampleDataUtil;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalSmartNus(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalSmartNus(), new UserPrefs());
+    private Model model = new ModelManager(SampleDataUtil.getSampleSmartNus(), new UserPrefs());
+    private Model expectedModel = new ModelManager(SampleDataUtil.getSampleSmartNus(), new UserPrefs());
 
     @Test
     public void equals() {
+        // TODO: add tags and importance predicates
         NameContainsKeywordsPredicate firstNamePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("first"));
         NameContainsKeywordsPredicate secondNamePredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        TagsContainKeywordsPredicate firstTagPredicate =
+                new TagsContainKeywordsPredicate(Collections.singletonList("first"));
+        TagsContainKeywordsPredicate secondTagPredicate =
+                new TagsContainKeywordsPredicate(List.of("first", "second"));
+        HasImportancePredicate firstImportancePredicate =
+                new HasImportancePredicate(new Importance("1"));
+        HasImportancePredicate secondImportancePredicate =
+                new HasImportancePredicate(new Importance("2"));
 
         ArrayList<Predicate<Question>> firstPredicateArr = new ArrayList<>();
-        firstPredicateArr.add(firstNamePredicate);
-        ArrayList<Predicate<Question>> secondPredicateArr = new ArrayList<>();
-        secondPredicateArr.add(secondNamePredicate);
+        firstPredicateArr.addAll(List.of(firstNamePredicate, firstTagPredicate, firstImportancePredicate));
         FindCommand findFirstCommand = new FindCommand(firstPredicateArr);
-        FindCommand findSecondCommand = new FindCommand(secondPredicateArr);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
@@ -56,40 +68,94 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different question -> returns false
-        assertFalse(findFirstCommand.equals(findSecondCommand));
-    }
+        // different name predicate -> returns false
+        ArrayList<Predicate<Question>> differentArr = new ArrayList<>();
+        differentArr.addAll(List.of(secondNamePredicate, firstTagPredicate, firstImportancePredicate));
+        assertFalse(findFirstCommand.equals(new FindCommand(differentArr)));
 
-    @Test
-    public void execute_zeroKeywords_noQuestionFound() {
-        String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 0);
-        ArrayList<Predicate<Question>> arr = new ArrayList<>();
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
-        arr.add(predicate);
-        FindCommand command = new FindCommand(arr);
-        expectedModel.updateFilteredQuestionList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredQuestionList());
-        assertEquals(model.getPanel(), QUESTION_KEYWORD);
+        // different tag predicate -> returns false
+        differentArr.clear();
+        differentArr.addAll(List.of(firstNamePredicate, secondTagPredicate, firstImportancePredicate));
+        assertFalse(findFirstCommand.equals(new FindCommand(differentArr)));
+
+        // different importance predicate -> returns false
+        differentArr.clear();
+        differentArr.addAll(List.of(firstNamePredicate, firstTagPredicate, secondImportancePredicate));
+        assertFalse(findFirstCommand.equals(new FindCommand(differentArr)));
     }
 
     @Test
     public void execute_multipleKeywords_oneQuestionFound() {
         String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 1);
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Fiona Kunz");
-        ArrayList<Predicate<Question>> arr = new ArrayList<>();
-        arr.add(predicate);
-        FindCommand command = new FindCommand(arr);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("grey-box test approaches");
+        ArrayList<Predicate<Question>> predicateArr = new ArrayList<>();
+        predicateArr.add(predicate);
+        FindCommand command = new FindCommand(predicateArr);
         expectedModel.updateFilteredQuestionList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(FIONA), model.getFilteredQuestionList());
+        assertEquals(Arrays.asList(getSampleQuestions()[TFQ_QUESTION_INDEX]), model.getFilteredQuestionList());
         assertEquals(model.getPanel(), QUESTION_KEYWORD);
+    }
+
+    @Test
+    public void execute_multipleKeywordsNotAllMatch_noQuestionFound() {
+        String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 0);
+        ArrayList<Predicate<Question>> predicateArr = new ArrayList<>();
+        NameContainsKeywordsPredicate predicate =
+                prepareNamePredicate("grey-box test approaches word-that-does-not-exist");
+        predicateArr.add(predicate);
+        FindCommand command = new FindCommand(predicateArr);
+        expectedModel.updateFilteredQuestionList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredQuestionList());
+    }
+
+    @Test
+    public void execute_multipleTagsOnlyOneMatches_fourQuestionsFound() {
+        String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 4);
+        ArrayList<Predicate<Question>> predicateArr = new ArrayList<>();
+        TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(List.of("CS2103T", "RandomTag"));
+        predicateArr.add(predicate);
+        FindCommand command = new FindCommand(predicateArr);
+        expectedModel.updateFilteredQuestionList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        Question[] questions = getSampleQuestions();
+        assertEquals(Arrays.asList(questions[0], questions[1], questions[4], questions[6]),
+                model.getFilteredQuestionList());
+    }
+
+    @Test
+    public void execute_wordWithPunctuationMarkMatch_oneQuestionFound() {
+        String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 1);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("standard");
+        ArrayList<Predicate<Question>> predicateArr = new ArrayList<>();
+        predicateArr.add(predicate);
+        FindCommand command = new FindCommand(predicateArr);
+        expectedModel.updateFilteredQuestionList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        // question contains "standard?" where "standard" should be taken as a full word match
+        assertEquals(Arrays.asList(getSampleQuestions()[MCQ_QUESTION_INDEX]), model.getFilteredQuestionList());
+    }
+
+    @Test
+    public void execute_multiplePredicates_oneQuestionFound() {
+        String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 1);
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("standard is");
+        TagsContainKeywordsPredicate tagPredicate = new TagsContainKeywordsPredicate(List.of("CS2103T", "Java"));
+        HasImportancePredicate importancePredicate = new HasImportancePredicate(new Importance("2"));
+        ArrayList<Predicate<Question>> predicateArr = new ArrayList<>();
+        predicateArr.addAll(List.of(namePredicate, tagPredicate, importancePredicate));
+        FindCommand command = new FindCommand(predicateArr);
+        expectedModel.updateFilteredQuestionList(namePredicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(getSampleQuestions()[MCQ_QUESTION_INDEX]), model.getFilteredQuestionList());
     }
 
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
     private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.trim()
+                .split("([,.?!:;*\"()\\[\\]{}]|\\s)+")));
     }
 }

--- a/src/test/java/seedu/smartnus/logic/commands/quiz/AnswerTfCommandTest.java
+++ b/src/test/java/seedu/smartnus/logic/commands/quiz/AnswerTfCommandTest.java
@@ -45,7 +45,6 @@ class AnswerTfqCommandTest {
 
     @Test
     public void execute_validInput_returnsCorrectCommandResult() {
-        quizManager.nextQuestion();
         Question question = quizManager.nextQuestion();
         Choice correctChoice = question.getCorrectChoice();
         int idx = question.getOrderedChoices().indexOf(correctChoice);
@@ -56,7 +55,6 @@ class AnswerTfqCommandTest {
 
     @Test
     public void execute_validInput_returnsIncorrectCommandResult() {
-        quizManager.nextQuestion();
         Question question = quizManager.nextQuestion();
         Choice correctChoice = question.getCorrectChoice();
         int idx = question.getOrderedChoices().indexOf(correctChoice);
@@ -68,7 +66,6 @@ class AnswerTfqCommandTest {
 
     @Test
     public void execute_multipleInputs_returnsAlreadyAnsweredCommandResult() {
-        quizManager.nextQuestion();
         quizManager.nextQuestion();
         answerTfqCommand = new AnswerTfqCommand("t", quizManager);
         answerTfqCommand.execute(model);

--- a/src/test/java/seedu/smartnus/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/smartnus/logic/parser/FindCommandParserTest.java
@@ -28,6 +28,22 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_invalidKeyword_throwsParseException() {
+        assertParseFailure(parser, ",.?!:;*()[]{}\"", FindCommand.MESSAGE_INVALID_KEYWORDS);
+    }
+
+    @Test
+    public void parse_validArgsWithPunctuation_returnsFindCommand() {
+        ArrayList<Predicate<Question>> predicates = new ArrayList<>();
+        NameContainsKeywordsPredicate expectedNamePredicate =
+                new NameContainsKeywordsPredicate(Arrays.asList("math", "english"));
+        predicates.add(expectedNamePredicate);
+        FindCommand expectedFindCommand =
+                new FindCommand(predicates);
+        assertParseSuccess(parser, "math,english!?", expectedFindCommand);
+    }
+
+    @Test
     public void parse_validArgs_returnsFindCommand() {
         // find by question name
         // no leading and trailing whitespaces


### PR DESCRIPTION
Previously, findcommand could not match full words when they start or end with punctuation. e.g. ```find abcd``` would not return a question called ```abcd?``` due to the additional question mark.

TODO: add tests for findcommandparser